### PR TITLE
Toggle display of badges

### DIFF
--- a/slappd/templates/config.j2
+++ b/slappd/templates/config.j2
@@ -20,6 +20,7 @@ token = D7NLHKQY37YMOI3S3L51R7AYOMKONFXYW9GTY6R4
 users = foo,bar,baz
 lastseen = 0
 display_media = true
+display_badges = true
 
 [slack]
 token = TXXXXXXXX/BXXXXXXXX/XXXXXXXXXXXXXXXXXXXXXXXX


### PR DESCRIPTION
 * Introduce new option to disable posting of badges earned by checkins.
 * Fix boolean determination for `display_media` -- it always evaluated to `True`.
 * Replace `SafeConfigParser` with `ConfigParser`, as suggested by deprecation warning by Python.