### PR TITLE
Optionally, show a link to the check-in that opens directly in the app

### DIFF
--- a/slappd/__main__.py
+++ b/slappd/__main__.py
@@ -197,8 +197,13 @@ def main():
                             text=badge['badge_description'])
 
                 # Render the message from a Jinja2 template
-                text += tmpl.render(checkin=checkin,
-                                    untappd_domain='https://untappd.com')
+                text += tmpl.render(
+                    checkin=checkin,
+                    untappd_domain='https://untappd.com',
+                    display_app_links=CONFIG['untappd'].getboolean(
+                        'display_app_links'
+                    ),
+                )
 
                 # Use the beer label as an icon if it exists
                 if checkin['beer']['beer_label']:

--- a/slappd/__main__.py
+++ b/slappd/__main__.py
@@ -200,8 +200,8 @@ def main():
                 text += tmpl.render(
                     checkin=checkin,
                     untappd_domain='https://untappd.com',
-                    display_app_links=CONFIG['untappd'].getboolean(
-                        'display_app_links'
+                    display_app_link=CONFIG['untappd'].getboolean(
+                        'display_app_link'
                     ),
                 )
 

--- a/slappd/templates/app-links.j2
+++ b/slappd/templates/app-links.j2
@@ -1,0 +1,1 @@
+<untappd://user/{{ checkin.user.user_name }}|:adult:> <untappd://beer/{{ checkin.beer.bid }}|:beer:> <untappd://brewery/{{ checkin.brewery.brewery_id }}|:factory:> {% if checkin.venue %}<untappd://venue/{{ checkin.venue.venue_id }}|:round_pushpin:>{% endif %}

--- a/slappd/templates/app-links.j2
+++ b/slappd/templates/app-links.j2
@@ -1,1 +1,0 @@
-<untappd://user/{{ checkin.user.user_name }}|:adult:> <untappd://beer/{{ checkin.beer.bid }}|:beer:> <untappd://brewery/{{ checkin.brewery.brewery_id }}|:factory:> {% if checkin.venue %}<untappd://venue/{{ checkin.venue.venue_id }}|:round_pushpin:>{% endif %}

--- a/slappd/templates/check-in.j2
+++ b/slappd/templates/check-in.j2
@@ -5,5 +5,6 @@
 {%- if checkin.venue %} at *<{{ untappd_domain }}/v/{{ checkin.venue.venue_slug
 }}/{{ checkin.venue.venue_id }}|{{ checkin.venue.venue_name | safe }}>*{% endif -%}
 {%- if checkin.rating_score %} ({{ checkin.rating_score }}/5){% endif %}
+{%- if display_app_links %} – open in app: <untappd://user/{{ checkin.user.user_name }}|:adult:> <untappd://beer/{{ checkin.beer.bid }}|:beer:> <untappd://brewery/{{ checkin.brewery.brewery_id }}|:factory:> {% if checkin.venue %}<untappd://venue/{{ checkin.venue.venue_id }}|:round_pushpin:>{% endif %}{% endif %}
 {% if checkin.checkin_comment %}> "{{ checkin.checkin_comment }}"
 {% endif %}

--- a/slappd/templates/check-in.j2
+++ b/slappd/templates/check-in.j2
@@ -5,6 +5,6 @@
 {%- if checkin.venue %} at *<{{ untappd_domain }}/v/{{ checkin.venue.venue_slug
 }}/{{ checkin.venue.venue_id }}|{{ checkin.venue.venue_name | safe }}>*{% endif -%}
 {%- if checkin.rating_score %} ({{ checkin.rating_score }}/5){% endif %}
-{%- if display_app_links %} – open in app: <untappd://user/{{ checkin.user.user_name }}|:adult:> <untappd://beer/{{ checkin.beer.bid }}|:beer:> <untappd://brewery/{{ checkin.brewery.brewery_id }}|:factory:> {% if checkin.venue %}<untappd://venue/{{ checkin.venue.venue_id }}|:round_pushpin:>{% endif %}{% endif %}
+{%- if display_app_link %} – <untappd://checkin/{{ checkin.checkin_id }}|open check-in in app :selfie:>{% endif %}
 {% if checkin.checkin_comment %}> "{{ checkin.checkin_comment }}"
 {% endif %}

--- a/slappd/templates/config.j2
+++ b/slappd/templates/config.j2
@@ -21,7 +21,7 @@ users = foo,bar,baz
 lastseen = 0
 display_media = true
 display_badges = true
-display_app_links = false
+display_app_link = false
 
 [slack]
 token = TXXXXXXXX/BXXXXXXXX/XXXXXXXXXXXXXXXXXXXXXXXX

--- a/slappd/templates/config.j2
+++ b/slappd/templates/config.j2
@@ -21,6 +21,7 @@ users = foo,bar,baz
 lastseen = 0
 display_media = true
 display_badges = true
+display_app_links = false
 
 [slack]
 token = TXXXXXXXX/BXXXXXXXX/XXXXXXXXXXXXXXXXXXXXXXXX


### PR DESCRIPTION
Originally, I provided direct links to all the same things (user, beer, brewery, location) that are already linked to on the website (see b640ac7f9b8a7c182bcff11d371cabed145e41f4).

But after discussing this with my friends, we agreed that simply linking to the check-in is the best solution, as the check-in gives easy access to everything mentioned before, and it's also where you can toast and comment.